### PR TITLE
Remove gnome-twitch

### DIFF
--- a/featured.section
+++ b/featured.section
@@ -2,7 +2,6 @@ vlc
 blender
 krita
 inkscape
-gnome-twitch
 drawing
 konversation
 glimpse-editor


### PR DESCRIPTION
gnome twitch is broken, and is no longer maintained upstream.